### PR TITLE
feat(docker): Add postgres to docker compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@
 
 # env file
 .env
+
+.DS_STORE

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY --from=base /burl /burl
 WORKDIR /burl/cmd/server
 RUN go build -o /burl/bin/burl 
 
-FROM gcr.io/distroless/static-debian11 as prod
+FROM gcr.io/distroless/static-debian11 AS prod
 COPY --from=builder /burl/bin/burl /burl
 EXPOSE 8080
 ENTRYPOINT ["./burl"]

--- a/cmd/server/config/config.go
+++ b/cmd/server/config/config.go
@@ -23,7 +23,7 @@ type Config struct {
 // New returns a new Config.
 func New() *Config {
 	v := viper.New()
-	v.SetEnvPrefix("burl")
+	v.SetEnvPrefix("burlserver")
 	v.AutomaticEnv()
 	return &Config{
 		viper: v,

--- a/cmd/server/config/config_test.go
+++ b/cmd/server/config/config_test.go
@@ -17,7 +17,7 @@ func TestNew(t *testing.T) {
 func TestConfig_DBURL(t *testing.T) {
 	t.Run("should return the DB URL", func(t *testing.T) {
 		c := config.New()
-		t.Setenv("BURL_DB_URL", "postgres://localhost:5432/burl")
+		t.Setenv("BURLSERVER_DB_URL", "postgres://localhost:5432/burl")
 		got, err := c.DBURL()
 		if err != nil {
 			t.Errorf("DBURL() error = %v; want nil", err)
@@ -39,7 +39,7 @@ func TestConfig_DBURL(t *testing.T) {
 func TestConfig_HTTPPort(t *testing.T) {
 	t.Run("should return the HTTP port", func(t *testing.T) {
 		c := config.New()
-		t.Setenv("BURL_HTTP_PORT", "8080")
+		t.Setenv("BURLSERVER_HTTP_PORT", "8080")
 		got, err := c.HTTPPort()
 		if err != nil {
 			t.Errorf("HTTPPort() error = %v; want nil", err)

--- a/cmd/server/root.go
+++ b/cmd/server/root.go
@@ -7,7 +7,7 @@ import (
 // NewRootCMD returns a new root command.
 func NewRootCMD() *cobra.Command {
 	return &cobra.Command{
-		Use:   "burl",
+		Use:   "burlserver",
 		Short: "b(ookmark)url is a developer first bookmark management tool written in Go",
 	}
 }

--- a/cmd/server/serve_test.go
+++ b/cmd/server/serve_test.go
@@ -16,8 +16,8 @@ func TestNewServeCMD(t *testing.T) {
 	})
 
 	t.Run("RunE should call Serve", func(t *testing.T) {
-		t.Setenv("BURL_DB_URL", "postgres://localhost:5432/burl")
-		t.Setenv("BURL_HTTP_PORT", "8080")
+		t.Setenv("BURLSERVER_DB_URL", "postgres://localhost:5432/burl")
+		t.Setenv("BURLSERVER_HTTP_PORT", "8080")
 		err := NewServeCMD().RunE(&cobra.Command{}, []string{})
 		if err != nil {
 			t.Errorf("NewServeCMD().RunE() error = %v; want nil", err)
@@ -28,8 +28,8 @@ func TestNewServeCMD(t *testing.T) {
 func TestServe(t *testing.T) {
 	t.Run("should start the server", func(t *testing.T) {
 		c := config.New()
-		t.Setenv("BURL_DB_URL", "postgres://localhost:5432/burl")
-		t.Setenv("BURL_HTTP_PORT", "8080")
+		t.Setenv("BURLSERVER_DB_URL", "postgres://localhost:5432/burl")
+		t.Setenv("BURLSERVER_HTTP_PORT", "8080")
 		err := Serve(context.TODO(), c)
 		if err != nil {
 			t.Errorf("Serve() error = %v; want nil", err)
@@ -38,7 +38,7 @@ func TestServe(t *testing.T) {
 
 	t.Run("should return an error if the DB URL is not set", func(t *testing.T) {
 		c := config.New()
-		t.Setenv("BURL_HTTP_PORT", "8080")
+		t.Setenv("BURLSERVER_HTTP_PORT", "8080")
 		err := Serve(context.TODO(), c)
 		if err == nil {
 			t.Error("Serve() error = nil; want an error")
@@ -47,7 +47,7 @@ func TestServe(t *testing.T) {
 
 	t.Run("should return an error if the HTTP port is not set", func(t *testing.T) {
 		c := config.New()
-		t.Setenv("BURL_DB_URL", "postgres://localhost:5432/burl")
+		t.Setenv("BURLSERVER_DB_URL", "postgres://localhost:5432/burl")
 		err := Serve(context.TODO(), c)
 		if err == nil {
 			t.Error("Serve() error = nil; want an error")

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,8 +1,37 @@
 services:
   burl:
+    container_name: burl-server
+    environment:
+      BURLSERVER_HTTP_PORT: 8080
+      BURLSERVER_DB_URL: "postgres://develop:develop_secret@database:5432/develop?sslmode=disable"
     image: burl
     build:
+      context: .  
       dockerfile: Dockerfile
       target: debug
     ports:
-      - "8080:8080"
+      - "8080:8080"  # For application.
+      - "2345:2345"  # For Delve debugger.
+    depends_on:
+      - postgres
+    volumes:
+      - .:/burl  
+    working_dir: /burl/cmd/server
+    command: [ "--", "serve"]
+    tty: true  
+    stdin_open: true  
+    
+  postgres:
+    container_name: database
+    image: postgres:16.4-alpine3.20
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U develop"] 
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: always
+    environment:
+      POSTGRES_USER: develop
+      POSTGRES_PASSWORD: develop_secret


### PR DESCRIPTION
# Changelog
Also renames `burl` to `burlserver` such that it does not conflict with the client cli which ideally is called `burl`.

### 🚀 Features

- *(docker)* Add postgres to docker compose



