### PR TITLE
feat(api): Add get children operation in API spec

### DIFF
--- a/api/openapi.v1.yaml
+++ b/api/openapi.v1.yaml
@@ -159,6 +159,28 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/BookmarkUpdate'
+  /users/{userId}/collections/{collectionId}/children:
+    get:
+      operationId: Collections_listChildren
+      description: List all the children of a collection, including bookmarks and sub-collections.
+      parameters:
+        - $ref: '#/components/parameters/CollectionKey.userId'
+        - $ref: '#/components/parameters/CollectionKey.collectionId'
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/CollectionChildren'
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
 components:
   parameters:
     BookmarkKey.bookmarkId:
@@ -306,6 +328,20 @@ components:
           type: string
           format: date-time
           readOnly: true
+    CollectionChildren:
+      type: object
+      required:
+        - bookmarks
+        - collections
+      properties:
+        bookmarks:
+          type: array
+          items:
+            $ref: '#/components/schemas/Bookmark'
+        collections:
+          type: array
+          items:
+            $ref: '#/components/schemas/Collection'
     CollectionCreate:
       type: object
       required:

--- a/api/typespec/main.tsp
+++ b/api/typespec/main.tsp
@@ -19,7 +19,6 @@ enum Versions {
     v1,
 }
 
-
 @resource("users")
 model User {
     @segment("users")
@@ -79,7 +78,6 @@ model Bookmark {
     name: string; 
     
     @key("bookmarkId")
-    @docFromComment
     @visibility("read")
     @doc("System-generated unique identifier for the bookmark.")
     uid: string; 
@@ -115,6 +113,12 @@ interface Bookmarks {
 }
 
 alias CollectionOperations = TypeSpec.Rest.Resource.ResourceOperations<Collection, Error>;
+alias CollectionParams = TypeSpec.Rest.Resource.ResourceParameters<Collection>;
+
+model CollectionChildren {
+    bookmarks: Bookmark[];
+    collections: Collection[];
+}
 
 @autoRoute
 interface Collections {
@@ -126,5 +130,9 @@ interface Collections {
 
     @doc("Update a collection")
     op update is CollectionOperations.update;
+
+    @segment("children")
+    @doc("List all the children of a collection, including bookmarks and sub-collections.")
+    op listChildren(...CollectionParams): CollectionChildren[] | Error;
 }
 

--- a/cmd/server/api/collection.go
+++ b/cmd/server/api/collection.go
@@ -33,3 +33,13 @@ func (s Server) CollectionsUpdate(
 	fmt.Printf("Updating collection %s for user %s\n", collectionID, userID)
 	w.WriteHeader(http.StatusNotImplemented)
 }
+
+func (s Server) CollectionsListChildren(
+	w http.ResponseWriter,
+	_ *http.Request,
+	userID string,
+	collectionID string,
+) {
+	fmt.Printf("Listing children of collection %s for user %s\n", collectionID, userID)
+	w.WriteHeader(http.StatusNotImplemented)
+}


### PR DESCRIPTION
As title. Would want to use OpenAPI union, but that compiles to `json.RawMessage` which I don't want to deal with.
