### PR TITLE
feat(config): Setup configuration with viper for client cli

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,13 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug burl client",
+            "type": "go",
+            "request": "launch",
+            "mode": "debug",
+            "program": "./cmd/burl",
+            "env": {},
+        }
+    ]
+}

--- a/cmd/burl/config.go
+++ b/cmd/burl/config.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+
+	"github.com/b-url/burl/cmd/burl/config"
+	"github.com/spf13/cobra"
+)
+
+type ConfigCommand struct {
+	command *cobra.Command
+}
+
+func NewConfigCommand() *ConfigCommand {
+	cmd := &ConfigCommand{}
+	cmd.command = &cobra.Command{
+		Use:   "config",
+		Short: "Manage the configuration of the burl command",
+	}
+
+	cmd.command.AddCommand(editConfigCommand)
+	return cmd
+}
+
+var editConfigCommand = &cobra.Command{
+	Use:   "edit",
+	Short: "Edit the configuration file",
+	RunE: func(_ *cobra.Command, _ []string) error {
+		config, err := config.New()
+		if err != nil {
+			return err
+		}
+
+		filepath, err := config.Write()
+		if err != nil {
+			return err
+		}
+
+		cmd := exec.Command("vi", filepath)
+		cmd.Stdin = os.Stdin
+		cmd.Stdout = os.Stdout
+
+		if err = cmd.Run(); err != nil {
+			return err
+		}
+
+		return nil
+	},
+}

--- a/cmd/burl/config/config.go
+++ b/cmd/burl/config/config.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/mitchellh/mapstructure"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -18,8 +19,17 @@ const (
 
 // Config represents the configuration of the burl command.
 type Config struct {
-	APIURL     string `yaml:"apiUrl"`
+	APIURL     string `yaml:"api-url"`
 	DeviceName string `yaml:"deviceName"`
+}
+
+func New() (Config, error) {
+	c := Config{}
+	err := viper.GetViper().Unmarshal(&c, viper.DecoderConfigOption(func(dc *mapstructure.DecoderConfig) {
+		dc.TagName = "yaml"
+	}))
+
+	return c, err
 }
 
 func Filepath() string {

--- a/cmd/burl/config/config.go
+++ b/cmd/burl/config/config.go
@@ -1,0 +1,50 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+const (
+	ConfigFileName    = "config.yaml"
+	ConfigFolder      = ".config/burl"
+	EnvironmentPrefix = "BURL"
+)
+
+// Config represents the configuration of the burl command.
+type Config struct {
+	APIURL     string `yaml:"apiUrl"`
+	DeviceName string `yaml:"deviceName"`
+}
+
+func Filepath() string {
+	home, err := os.UserHomeDir()
+	cobra.CheckErr(err)
+
+	configPath := filepath.Join(home, ConfigFolder)
+	burlConfigPath := filepath.Join(configPath, ConfigFileName)
+
+	return burlConfigPath
+}
+
+func Init() {
+	fmt.Println("Initializing config")
+	configFile := Filepath()
+
+	viper.SetConfigType("yaml")
+	viper.SetConfigFile(configFile)
+	viper.SetConfigPermissions(os.FileMode(0600))
+
+	viper.SetEnvPrefix(EnvironmentPrefix)
+	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
+	viper.AutomaticEnv()
+
+	if err := viper.ReadInConfig(); err == nil {
+		fmt.Println("Using config file:", viper.ConfigFileUsed())
+	}
+}

--- a/cmd/burl/config/config_test.go
+++ b/cmd/burl/config/config_test.go
@@ -1,0 +1,25 @@
+package config_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/b-url/burl/cmd/burl/config"
+)
+
+func TestDefaultConfigFolder(t *testing.T) {
+	t.Run("should return the default config folder path", func(t *testing.T) {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			t.Fatalf("os.UserHomeDir() error = %v; want nil", err)
+		}
+
+		expected := filepath.Join(home, ".config", config.ConfigFolder)
+		got := config.Filepath()
+
+		if got != expected {
+			t.Errorf("DefaultConfigFolder() = %s; want %s", got, expected)
+		}
+	})
+}

--- a/cmd/burl/config/config_test.go
+++ b/cmd/burl/config/config_test.go
@@ -15,7 +15,7 @@ func TestDefaultConfigFolder(t *testing.T) {
 			t.Fatalf("os.UserHomeDir() error = %v; want nil", err)
 		}
 
-		expected := filepath.Join(home, ".config", config.ConfigFolder)
+		expected := filepath.Join(home, config.ConfigFolder, config.ConfigFileName)
 		got := config.Filepath()
 
 		if got != expected {

--- a/cmd/burl/main.go
+++ b/cmd/burl/main.go
@@ -3,9 +3,9 @@ package main
 import "os"
 
 func main() {
-	rootCmd := NewRootCMD()
+	rootCmd := NewRootCommand()
 
-	if err := rootCmd.Execute(); err != nil {
+	if err := rootCmd.command.Execute(); err != nil {
 		os.Exit(1)
 	}
 }

--- a/cmd/burl/root.go
+++ b/cmd/burl/root.go
@@ -42,8 +42,15 @@ func NewRootCommand() *RootCommand {
 }
 
 func (c *RootCommand) Execute(_ *cobra.Command, _ []string) error {
+	config, err := config.New()
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("API URL:", config.APIURL)
+
 	p := tea.NewProgram(tui.New(), tea.WithAltScreen())
-	_, err := p.Run()
+	_, err = p.Run()
 	return err
 }
 

--- a/cmd/burl/root.go
+++ b/cmd/burl/root.go
@@ -1,20 +1,60 @@
 package main
 
 import (
+	"fmt"
+
+	"github.com/b-url/burl/cmd/burl/config"
 	"github.com/b-url/burl/cmd/burl/tui"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
 )
 
-// NewRootCMD returns a new root command.
-func NewRootCMD() *cobra.Command {
-	return &cobra.Command{
+const (
+	ArgsAPIURL          = "api-url"
+	ArgsAPIURLShortname = "a"
+)
+
+type RootCommand struct {
+	command *cobra.Command
+}
+
+func NewRootCommand() *RootCommand {
+	cobra.OnInitialize(config.Init)
+
+	cmd := &RootCommand{}
+	cmd.command = &cobra.Command{
 		Use:   "burl",
-		Short: "b(ookmark)url is a developer first bookmark management tool written in Go",
-		RunE: func(_ *cobra.Command, _ []string) error {
-			p := tea.NewProgram(tui.New(), tea.WithAltScreen())
-			_, err := p.Run()
-			return err
+		Short: "b(ookmark)url is a command-line bookmark manager",
+		PersistentPreRun: func(cmd *cobra.Command, _ []string) {
+			bindFlags(cmd, viper.GetViper())
 		},
+		RunE: cmd.Execute,
 	}
+
+	pflags := cmd.command.PersistentFlags()
+
+	pflags.StringP(ArgsAPIURL, ArgsAPIURLShortname, "", "API URL")
+	_ = viper.BindPFlag(ArgsAPIURL, pflags.Lookup(ArgsAPIURL))
+
+	return cmd
+}
+
+func (c *RootCommand) Execute(_ *cobra.Command, _ []string) error {
+	p := tea.NewProgram(tui.New(), tea.WithAltScreen())
+	_, err := p.Run()
+	return err
+}
+
+// Bind each cobra flag to its associated viper configuration (config file and environment variable).
+func bindFlags(cmd *cobra.Command, v *viper.Viper) {
+	cmd.Flags().VisitAll(func(f *pflag.Flag) {
+		configName := f.Name
+
+		if !f.Changed && v.IsSet(configName) {
+			val := v.Get(configName)
+			_ = cmd.Flags().Set(f.Name, fmt.Sprintf("%v", val))
+		}
+	})
 }

--- a/cmd/burl/root.go
+++ b/cmd/burl/root.go
@@ -12,8 +12,7 @@ import (
 )
 
 const (
-	ArgsAPIURL          = "api-url"
-	ArgsAPIURLShortname = "a"
+	ArgsAPIURL = config.APIURLName
 )
 
 type RootCommand struct {
@@ -33,9 +32,11 @@ func NewRootCommand() *RootCommand {
 		RunE: cmd.Execute,
 	}
 
+	cmd.command.AddCommand(NewConfigCommand().command)
+
 	pflags := cmd.command.PersistentFlags()
 
-	pflags.StringP(ArgsAPIURL, ArgsAPIURLShortname, "", "API URL")
+	pflags.String(ArgsAPIURL, "", "API URL")
 	_ = viper.BindPFlag(ArgsAPIURL, pflags.Lookup(ArgsAPIURL))
 
 	return cmd
@@ -48,6 +49,7 @@ func (c *RootCommand) Execute(_ *cobra.Command, _ []string) error {
 	}
 
 	fmt.Println("API URL:", config.APIURL)
+	// TODO: Init client with API URL and inject in tui.New()
 
 	p := tea.NewProgram(tui.New(), tea.WithAltScreen())
 	_, err = p.Run()

--- a/cmd/burl/tui/statusbar.go
+++ b/cmd/burl/tui/statusbar.go
@@ -25,7 +25,6 @@ func NewStatusBar(initCollection string) *StatusBar {
 	return &StatusBar{currentCollection: initCollection, version: "v0.0.1-alpha"} // TODO: get version from somewhere
 }
 
-// Update updates the footer.
 func (f *StatusBar) Update(collection string) {
 	f.currentCollection = collection
 }
@@ -34,7 +33,6 @@ func (f *StatusBar) SetSize(width int) {
 	f.width = width
 }
 
-// View returns the footer view.
 func (f *StatusBar) View() string {
 	width := lipgloss.Width
 

--- a/cmd/burl/tui/table.go
+++ b/cmd/burl/tui/table.go
@@ -8,8 +8,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
-var baseStyle = lipgloss.NewStyle().
-	BorderForeground(lipgloss.Color("240"))
+var baseStyle = lipgloss.NewStyle().BorderForeground(lipgloss.Color("240"))
 
 type Table struct {
 	width int


### PR DESCRIPTION
# Changelog
This PR sets up the cobra app for the client with Viper.
The configuration can be set in three ways: via command-line flags, environment variables, and configuration files. Here is the order of precedence from highest to lowest:

1. **Command-Line Flags**: The highest precedence. Settings provided as command-line arguments override those set in environment variables and configuration files.

2. **Environment Variables**: The middle precedence. Environment variables override settings in configuration files but are overridden by command-line flags.

3. **Configuration Files**: The lowest precedence. These settings are overridden by both environment variables and command-line flags.

Additionally a `burl config edit` convenience command is added to open the current config in `vi`.

https://github.com/user-attachments/assets/8258f0ce-b18f-4ec9-9d3e-6d69a59e7f7f


### 🚀 Features

- *(burl)* Add config package with fallback on file
- *(config)* Add New function to get Config
- *(config)* Add command to edit the configuration



