### PR TITLE
Feature/dbc

### DIFF
--- a/cmd/server/dbc/dbc.go
+++ b/cmd/server/dbc/dbc.go
@@ -1,0 +1,67 @@
+package dbc
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
+)
+
+var (
+	_ Conn = (*sql.DB)(nil)
+	_ Conn = (*sql.Tx)(nil)
+)
+
+// Conn represents a connection to a database.
+// It is implemented by *sql.DB and *sql.Tx and can be used to perform queries and execute statements.
+type Conn interface {
+	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
+}
+
+// Manager manages the database connection.
+type Manager struct {
+	logger *slog.Logger
+	db     *sql.DB
+}
+
+// NewManager creates a new Manager.
+func NewManager(lgger *slog.Logger, db *sql.DB) *Manager {
+	return &Manager{db: db}
+}
+
+// DB returns the database connection.
+func (m *Manager) DB() *sql.DB {
+	return m.db
+}
+
+// TX executes the function f in a transaction.
+func (m *Manager) TX(ctx context.Context, f func(tx Conn) error) error {
+	tx, err := m.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		if p := recover(); p != nil {
+			tx.Rollback()
+			panic(p)
+		}
+	}()
+
+	if err := f(tx); err != nil {
+		m.logger.Error("transaction error", slog.String("error", err.Error()))
+		if rErr := tx.Rollback(); rErr != nil {
+			return fmt.Errorf("rollback error: %w", rErr)
+		}
+		return err
+	}
+
+	err = tx.Commit()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/server/login/otp/notifier.go
+++ b/cmd/server/login/otp/notifier.go
@@ -1,0 +1,35 @@
+package otp
+
+import (
+	"fmt"
+	"io"
+)
+
+// Notification is a struct that contains the token and contact details of the user.
+type Notification struct {
+	Password string // Password is the password of the user
+	Email    string // Email is the email address of the user
+}
+
+// Notifier notifies the user of the token.
+type Notifier interface {
+	Notify(Notification) error
+}
+
+// NotifierWriter implements the Notifier interface and writes the token to the writer.
+type NotifierWriter struct {
+	w io.Writer
+}
+
+// NewWriter returns a new Writer.
+func NewNotifierWriter(w io.Writer) *NotifierWriter {
+	return &NotifierWriter{w: w}
+}
+
+func (n *NotifierWriter) Notify(d Notification) error {
+	_, err := n.w.Write([]byte(fmt.Sprintf("Password: %q Email: %q\n", d.Password, d.Email)))
+	if err != nil {
+		return fmt.Errorf("failed to write token: %w", err)
+	}
+	return err
+}

--- a/cmd/server/login/otp/notifier_test.go
+++ b/cmd/server/login/otp/notifier_test.go
@@ -1,0 +1,51 @@
+package otp_test
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/b-url/burl/cmd/server/login/otp"
+)
+
+// MockWriter is a mock implementation of the io.Writer interface.
+type MockWriter struct {
+	err error
+}
+
+// Write writes the token and email to the writer.
+func (m *MockWriter) Write(p []byte) (int, error) {
+	return len(p), m.err
+}
+
+func TestNewWriter(t *testing.T) {
+	if otp.NewNotifierWriter(nil) == nil {
+		t.Error("NewWriter returned nil")
+	}
+}
+
+func TestWriter_Notify(t *testing.T) {
+	t.Run("writer should write the token and email", func(t *testing.T) {
+		w := &strings.Builder{}
+		writer := otp.NewNotifierWriter(w)
+		d := otp.Notification{Password: "Password", Email: "email"}
+		err := writer.Notify(d)
+		if err != nil {
+			t.Errorf("Writer.Notify() error = %v", err)
+		}
+		if got := w.String(); got != fmt.Sprintf("Password: %q Email: %q\n", d.Password, d.Email) {
+			t.Errorf("Writer.Notify() = %v, want %v", got, fmt.Sprintf("Password: %q Email: %q\n", d.Password, d.Email))
+		}
+	})
+
+	t.Run("writer should return error if write fails", func(t *testing.T) {
+		var expectedErr = errors.New("write error")
+		w := &MockWriter{err: expectedErr}
+		writer := otp.NewNotifierWriter(w)
+		d := otp.Notification{Password: "Password", Email: "email"}
+		if err := writer.Notify(d); !errors.Is(err, expectedErr) {
+			t.Errorf("Writer.Notify() error = %v, want %v", err, expectedErr)
+		}
+	})
+}

--- a/cmd/server/login/otp/otp.go
+++ b/cmd/server/login/otp/otp.go
@@ -1,0 +1,23 @@
+package otp
+
+const passwordLength = 6 // passwordLength is the length of the OTP password.
+
+// OTP is One-Time Password authentication mechanism that is used to authenticate the user.
+type OTP struct {
+	notifier  Notifier
+	generator Generator
+}
+
+// New returns a new OTP.
+func New(notifier Notifier, generator Generator) *OTP {
+	return &OTP{notifier: notifier, generator: generator}
+}
+
+func (o *OTP) Send(email string) error {
+	token, err := o.generator.Generate(passwordLength)
+	if err != nil {
+		return err
+	}
+	// todo: save token to the database
+	return o.notifier.Notify(Notification{Password: token, Email: email})
+}

--- a/cmd/server/login/otp/otp.go
+++ b/cmd/server/login/otp/otp.go
@@ -1,3 +1,4 @@
+// Package otp provides the One-Time Password authentication mechanism.
 package otp
 
 const passwordLength = 6 // passwordLength is the length of the OTP password.

--- a/cmd/server/login/otp/otp_test.go
+++ b/cmd/server/login/otp/otp_test.go
@@ -16,7 +16,7 @@ func TestNewOTP(t *testing.T) {
 func TestOTP_Create(t *testing.T) {
 	t.Run("should return error if generator fails", func(t *testing.T) {
 		var genErr = errors.New("err")
-		o := otp.New(nil, otp.GeneratorFunc(func(length int) (string, error) {
+		o := otp.New(nil, otp.GeneratorFunc(func(_ int) (string, error) {
 			return "", genErr
 		}))
 		if err := o.Send(""); !errors.Is(err, genErr) {
@@ -27,7 +27,7 @@ func TestOTP_Create(t *testing.T) {
 	t.Run("should return error if notifier fails", func(t *testing.T) {
 		var notifierErr = errors.New("err")
 		w := &MockWriter{err: nil}
-		o := otp.New(otp.NewNotifierWriter(w), otp.GeneratorFunc(func(length int) (string, error) {
+		o := otp.New(otp.NewNotifierWriter(w), otp.GeneratorFunc(func(_ int) (string, error) {
 			return "token", notifierErr
 		}))
 		if err := o.Send(""); !errors.Is(err, notifierErr) {

--- a/cmd/server/login/otp/otp_test.go
+++ b/cmd/server/login/otp/otp_test.go
@@ -1,0 +1,37 @@
+package otp_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/b-url/burl/cmd/server/login/otp"
+)
+
+func TestNewOTP(t *testing.T) {
+	if otp.New(nil, nil) == nil {
+		t.Error("NewOTP returned nil")
+	}
+}
+
+func TestOTP_Create(t *testing.T) {
+	t.Run("should return error if generator fails", func(t *testing.T) {
+		var genErr = errors.New("err")
+		o := otp.New(nil, otp.GeneratorFunc(func(length int) (string, error) {
+			return "", genErr
+		}))
+		if err := o.Send(""); !errors.Is(err, genErr) {
+			t.Errorf("OTP.Create() error = %v, want %v", err, genErr)
+		}
+	})
+
+	t.Run("should return error if notifier fails", func(t *testing.T) {
+		var notifierErr = errors.New("err")
+		w := &MockWriter{err: nil}
+		o := otp.New(otp.NewNotifierWriter(w), otp.GeneratorFunc(func(length int) (string, error) {
+			return "token", notifierErr
+		}))
+		if err := o.Send(""); !errors.Is(err, notifierErr) {
+			t.Errorf("OTP.Create() error = %v, want %v", err, notifierErr)
+		}
+	})
+}

--- a/cmd/server/login/otp/password.go
+++ b/cmd/server/login/otp/password.go
@@ -1,0 +1,36 @@
+package otp
+
+import (
+	"crypto/rand"
+	"math/big"
+)
+
+// Generator is an interface that generates a random string.
+type Generator interface {
+	Generate(length int) (string, error)
+}
+
+type GeneratorFunc func(length int) (string, error)
+
+func (g GeneratorFunc) Generate(length int) (string, error) {
+	return g(length)
+}
+
+// generateNumericOTP generates a numeric one-time password of the given length.
+func generateNumericOTP(length int) (string, error) {
+	const digits = "0123456789"
+	otp := make([]byte, length)
+	for i := range otp {
+		num, err := rand.Int(rand.Reader, big.NewInt(int64(len(digits))))
+		if err != nil {
+			return "", err
+		}
+		otp[i] = digits[num.Int64()]
+	}
+	return string(otp), nil
+}
+
+// NewNumericOTPGenerator returns a new numeric OTP generator.
+func NewNumericOTPGenerator() Generator {
+	return GeneratorFunc(generateNumericOTP)
+}

--- a/cmd/server/login/otp/password_test.go
+++ b/cmd/server/login/otp/password_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestGeneratorFunc_Generate(t *testing.T) {
-	f := func(length int) (string, error) {
+	f := func(_ int) (string, error) {
 		return "123456", nil
 	}
 

--- a/cmd/server/login/otp/password_test.go
+++ b/cmd/server/login/otp/password_test.go
@@ -1,0 +1,36 @@
+package otp_test
+
+import (
+	"testing"
+
+	"github.com/b-url/burl/cmd/server/login/otp"
+)
+
+func TestGeneratorFunc_Generate(t *testing.T) {
+	f := func(length int) (string, error) {
+		return "123456", nil
+	}
+
+	g := otp.GeneratorFunc(f)
+	got, err := g.Generate(6)
+	if err != nil {
+		t.Errorf("GeneratorFunc.Generate() error = %v", err)
+	}
+	if got != "123456" {
+		t.Errorf("GeneratorFunc.Generate() = %v, want %v", got, "123456")
+	}
+}
+
+func TestNewNumericOTPGenerator(t *testing.T) {
+	g := otp.NewNumericOTPGenerator()
+	if g == nil {
+		t.Error("NewNumericOTPGenerator returned nil")
+	}
+	got, err := g.Generate(6)
+	if err != nil {
+		t.Errorf("NewNumericOTPGenerator.Generate() error = %v", err)
+	}
+	if len(got) != 6 {
+		t.Errorf("NewNumericOTPGenerator.Generate() = %v, want a length of %v", got, 6)
+	}
+}

--- a/cmd/server/user/repository.go
+++ b/cmd/server/user/repository.go
@@ -1,0 +1,77 @@
+package user
+
+import (
+	"context"
+
+	"github.com/b-url/burl/cmd/server/dbc"
+	"github.com/google/uuid"
+)
+
+// Repository provides access to the user storage.
+type Repository interface {
+	Create(context.Context, User) error
+	Get(context.Context, uuid.UUID) (User, error)
+	GetByEmail(context.Context, string) (User, error)
+	Update(context.Context, User) error
+	Delete(context.Context, uuid.UUID) error
+}
+
+// SQLRepository represents a SQL repository.
+type SQLRepository struct {
+	dbc dbc.Conn
+}
+
+// NewSQLRepository creates a new SQLRepository.
+func NewSQLRepository(dbc dbc.Conn) *SQLRepository {
+	return &SQLRepository{dbc: dbc}
+}
+
+// Create creates a new user.
+func (r *SQLRepository) Create(ctx context.Context, u User) error {
+	_, err := r.dbc.ExecContext(ctx, `
+		INSERT INTO users (id, username, email, create_time, update_time)
+		VALUES ($1, $2, $3, $4, $5)
+	`, u.ID, u.Username, u.Email, u.CreateTime, u.UpdateTime)
+	return err
+}
+
+// Get returns the user with the specified ID.
+func (r *SQLRepository) Get(ctx context.Context, id uuid.UUID) (User, error) {
+	var u User
+	err := r.dbc.QueryRowContext(ctx, `
+		SELECT id, username, email, create_time, update_time
+		FROM users
+		WHERE id = $1
+	`, id).Scan(&u.ID, &u.Username, &u.Email, &u.CreateTime, &u.UpdateTime)
+	return u, err
+}
+
+// GetByEmail returns the user with the specified email.
+func (r *SQLRepository) GetByEmail(ctx context.Context, email string) (User, error) {
+	var u User
+	err := r.dbc.QueryRowContext(ctx, `
+		SELECT id, username, email, create_time, update_time
+		FROM users
+		WHERE email = $1
+	`, email).Scan(&u.ID, &u.Username, &u.Email, &u.CreateTime, &u.UpdateTime)
+	return u, err
+}
+
+// Update updates the user.
+func (r *SQLRepository) Update(ctx context.Context, u User) error {
+	_, err := r.dbc.ExecContext(ctx, `
+		UPDATE users
+		SET username = $1, email = $2, update_time = $3
+		WHERE id = $4
+	`, u.Username, u.Email, u.UpdateTime, u.ID)
+	return err
+}
+
+// Delete deletes the user with the specified ID.
+func (r *SQLRepository) Delete(ctx context.Context, id uuid.UUID) error {
+	_, err := r.dbc.ExecContext(ctx, `
+		DELETE FROM users
+		WHERE id = $1
+	`, id)
+	return err
+}

--- a/cmd/server/user/user.go
+++ b/cmd/server/user/user.go
@@ -1,1 +1,16 @@
 package user
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// User represents the user entity.
+type User struct {
+	ID         uuid.UUID
+	Username   string
+	Email      string
+	CreateTime time.Time
+	UpdateTime time.Time
+}


### PR DESCRIPTION
Proposal for introducing an dbc package which can be used to run transaction in the service layer.
Repositories should use the dbc.Conn type and should not worry about tx's. 

example:

```go
// TX example
m := dbc.NewManager(db)
err := m.Tx(ctx, func(c dbc.Conn) error {
   userRepo := user.NewSQLRepository(c)
   
   userRepo.Update(...)
   userRepo.Delete(...)
   
   return nil
})

if err != nil {
    ...
}
```


```go
// No TX example
m := dbc.NewManager(db)
repo := user.NewSQLRepository(m.DB())
repo.Update(...)
```